### PR TITLE
feat(client): Add ability to subscribe to a list of ticker pairs.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -76,7 +76,7 @@ export class Client {
 
   subscribeTicker(symbol: string): void {
     this.requireSocketToBeOpen();
-    const formatSymbol = symbol.replace('/', '-');
+    const formatSymbol = symbol.split('/').join('-');
     const indexSubscription = getTickerSubscriptionKey(symbol);
 
     if (this.subscriptions.includes(indexSubscription)) {
@@ -127,7 +127,7 @@ export class Client {
 
   unsubscribeTicker(symbol: string): void {
     this.requireSocketToBeOpen();
-    const formatSymbol = symbol.replace('/', '-');
+    const formatSymbol = symbol.split('/').join('-');
     const indexSubscription = getTickerSubscriptionKey(symbol);
 
     if (!this.subscriptions.includes(indexSubscription)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,20 +18,30 @@ export class KuCoinWs extends Emittery {
   }
 
   subscribeTicker(symbol: string): void {
+    this.subscribeTickers([symbol]);
+  }
+
+  subscribeTickers(symbols: string[]): void {
+    const symbolsArrayAsString = symbols.join(',');
     const alreadySubscribed = this.clientList.some((client: Client) =>
-      client.getSubscriptions().includes(getTickerSubscriptionKey(symbol)),
+      client.getSubscriptions().includes(getTickerSubscriptionKey(symbolsArrayAsString)),
     );
 
     if (alreadySubscribed) {
       return;
     }
 
-    this.getLastClient().then((client: Client) => client.subscribeTicker(symbol));
+    this.getLastClient().then((client: Client) => client.subscribeTicker(symbolsArrayAsString));
   }
 
   unsubscribeTicker(symbol: string): void {
+    this.unsubscribeTickers([symbol]);
+  }
+
+  unsubscribeTickers(symbols: string[]): void {
+    const symbolsArrayAsString = symbols.join(',');
     const alreadySubscribed = this.clientList.some((client: Client) =>
-      client.getSubscriptions().includes(getTickerSubscriptionKey(symbol)),
+      client.getSubscriptions().includes(getTickerSubscriptionKey(symbolsArrayAsString)),
     );
 
     if (!alreadySubscribed) {
@@ -39,10 +49,10 @@ export class KuCoinWs extends Emittery {
     }
 
     const client = this.clientList.find((client: Client) =>
-      client.getSubscriptions().includes(getTickerSubscriptionKey(symbol)),
+      client.getSubscriptions().includes(getTickerSubscriptionKey(symbolsArrayAsString)),
     );
 
-    client.unsubscribeTicker(symbol);
+    client.unsubscribeTicker(symbolsArrayAsString);
   }
 
   subscribeCandle(symbol: string, interval: string): void {

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -24,12 +24,14 @@ const main = async () => {
   client.subscribeTicker('ZIL/USDT');
   client.subscribeTicker('KSM/USDT');
   client.subscribeTicker('LINK/USDT');
+  client.subscribeTickers(['BTC/USDT', 'VET/USDT', 'XRP/USDT']);
   client.subscribeCandle('BTC/USDT', '1m');
   client.subscribeCandle('ETH/USDT', '1m');
 
   await delay(2000);
 
   client.unsubscribeTicker('BTC/USDT');
+  client.unsubscribeTickers(['BTC/USDT', 'VET/USDT', 'XRP/USDT']);
   unSubFn();
 };
 


### PR DESCRIPTION
Good afternoon,

I emailed you last night about this proposed change. It would not let me create a branch to PR, so I forked to PR. Here is my solution:

I extended the index.ts by creating two new methods to handle an array of tickers for subscribe and unsubscribe. I modified the existing subscribe and unsubscribe to use the new methods, but left the originals as is for legacy / backwards compatibility. 

I had to pollyfill the replace() to be a split() and join() because it will only replace the first occurrence, and when you have a list of tickers, there could be multiple. There is an available method 'replaceAll' but It's not available until ES2021, which could be upgraded. I am unaware of your existing backwards compatibility, so I pollyfilled.

I decided to store all tickers as a single subscription. This makes it so you need to subscribe and unsubscribe to all wanted tickers at once. Otherwise if we add in individual tickers to the existing array, and you chose to unsubscribe, it would unsubscribe to every instance of that ticker which may not be the intended result. Storing an entire string of tickers alleviates this potential issue and is the expected param for the socket itself. Example String: "ticker-eth/usdt,vet/usdt,xrp/usdt"

I am unaware of your release process. I did not know if I was supposed to run release / prerelease to increment version or if this is a part of your pipeline. I did not include my dist files as I am under the assumption your project builds in the pipeline. Let me know if I need to do these additional steps to satisfy the PR.